### PR TITLE
Bugfix: Crate breaking, potion drop logic, and player stat sync

### DIFF
--- a/Siomeow Legends/Assets/Animation/Objects/Crate/Crate.controller
+++ b/Siomeow Legends/Assets/Animation/Objects/Crate/Crate.controller
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1101 &-6411192569373269877
+--- !u!1101 &-8487209329607853763
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,104 +8,24 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 3
-    m_ConditionEvent: Damage
+  - m_ConditionMode: 1
+    m_ConditionEvent: Broken
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -2846764730142716504}
+  m_DstState: {fileID: 5251686899863533579}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0.375
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1102 &-2846764730142716504
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: BreakCrate
-  m_Speed: 0.1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 333170148642889481}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 58a14e7f12edc3f44bf1e429ed7b6901, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
---- !u!91 &9100000
-AnimatorController:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Crate
-  serializedVersion: 5
-  m_AnimatorParameters:
-  - m_Name: Damage
-    m_Type: 1
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  m_AnimatorLayers:
-  - serializedVersion: 5
-    m_Name: Base Layer
-    m_StateMachine: {fileID: 6523400179395000698}
-    m_Mask: {fileID: 0}
-    m_Motions: []
-    m_Behaviours: []
-    m_BlendingMode: 0
-    m_SyncedLayerIndex: -1
-    m_DefaultWeight: 0
-    m_IKPass: 0
-    m_SyncedLayerAffectsTiming: 0
-    m_Controller: {fileID: 9100000}
---- !u!1101 &333170148642889481
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 4
-    m_ConditionEvent: Damage
-    m_EventTreshold: 1
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 7113196965704743453}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1107 &6523400179395000698
+--- !u!1107 &-7566849831808760647
 AnimatorStateMachine:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -115,33 +35,61 @@ AnimatorStateMachine:
   m_Name: Base Layer
   m_ChildStates:
   - serializedVersion: 1
-    m_State: {fileID: 7113196965704743453}
-    m_Position: {x: 30, y: 190, z: 0}
+    m_State: {fileID: 5236564708908062632}
+    m_Position: {x: 30, y: 200, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: -2846764730142716504}
-    m_Position: {x: 30, y: 260, z: 0}
+    m_State: {fileID: 5251686899863533579}
+    m_Position: {x: 30, y: 270, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_AnyStatePosition: {x: 50, y: 50, z: 0}
   m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ExitPosition: {x: 260, y: 50, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 7113196965704743453}
---- !u!1102 &7113196965704743453
+  m_DefaultState: {fileID: 5236564708908062632}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Crate
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Broken
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -7566849831808760647}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &5236564708908062632
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Idle
+  m_Name: CrateIdle
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -6411192569373269877}
+  - {fileID: -8487209329607853763}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -157,3 +105,55 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &5251686899863533579
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BreakCrate
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8877283845614931849}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 58a14e7f12edc3f44bf1e429ed7b6901, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &8877283845614931849
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Broken
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5236564708908062632}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/Siomeow Legends/Assets/Prefabs/Items/Crate.prefab
+++ b/Siomeow Legends/Assets/Prefabs/Items/Crate.prefab
@@ -11,9 +11,9 @@ GameObject:
   - component: {fileID: 7061964570005988212}
   - component: {fileID: 2006536516626116102}
   - component: {fileID: 4983694036338440896}
-  - component: {fileID: 3052407128424002304}
   - component: {fileID: 7166348317633131730}
-  - component: {fileID: 2315019466878276781}
+  - component: {fileID: 451648685825780469}
+  - component: {fileID: 3052407128424002304}
   - component: {fileID: 4850532283164375856}
   m_Layer: 8
   m_Name: Crate
@@ -114,20 +114,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &3052407128424002304
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835547865163386838}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58730558262523f47abae6acb2666c2a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healthPotionPrefab: {fileID: 2633245788659597330, guid: febc8454eec7e8e49b411b9cf1e2ce67, type: 3}
-  defensePotionPrefab: {fileID: 353630234702561675, guid: d2f44e7ed9c56e1409f666631133f737, type: 3}
 --- !u!114 &7166348317633131730
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -153,7 +139,7 @@ MonoBehaviour:
   AutoObjectParentSync: 1
   SyncOwnerTransformWhenParented: 1
   AllowOwnerToParent: 0
---- !u!114 &2315019466878276781
+--- !u!114 &451648685825780469
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -162,16 +148,28 @@ MonoBehaviour:
   m_GameObject: {fileID: 1835547865163386838}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a2c93109caf2b3846817c825c3c0bc6d, type: 3}
+  m_Script: {fileID: 11500000, guid: 4479c7b4913eefa4596bddc87616b9e9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   ShowTopMostFoldoutHeaderGroup: 1
   health:
-    m_InternalValue: 3607
-  defense:
-    m_InternalValue: 400
-  damageMultiplier: 1
-  anim: {fileID: 0}
+    m_InternalValue: 1
+  anim: {fileID: 4983694036338440896}
+--- !u!114 &3052407128424002304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1835547865163386838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58730558262523f47abae6acb2666c2a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  healthPotionPrefab: {fileID: 2633245788659597330, guid: febc8454eec7e8e49b411b9cf1e2ce67, type: 3}
+  defensePotionPrefab: {fileID: 353630234702561675, guid: d2f44e7ed9c56e1409f666631133f737, type: 3}
 --- !u!61 &4850532283164375856
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Siomeow Legends/Assets/Scripts/Objects/CrateStats.cs
+++ b/Siomeow Legends/Assets/Scripts/Objects/CrateStats.cs
@@ -47,6 +47,8 @@ public class CrateStats : NetworkBehaviour
         // Properly despawn the networked object
         if (IsServer)
         {
+            GetComponent<LootCrate>()?.DropPotion(); 
+    
             // Despawn the crate to sync destruction across all clients
             GetComponent<NetworkObject>().Despawn();
         }

--- a/Siomeow Legends/Assets/Scripts/Objects/CrateStats.cs
+++ b/Siomeow Legends/Assets/Scripts/Objects/CrateStats.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections;
+using Unity.Netcode;
+using UnityEngine;
+
+public class CrateStats : NetworkBehaviour
+{
+    // CRATE STATS
+    public NetworkVariable<int> health = new NetworkVariable<int>(1, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Server);
+
+    // STAT LIMITS
+    public const int MAX_HEALTH = 1;
+    private bool isBreak = false;
+
+    public Animator anim;
+
+    [ServerRpc(RequireOwnership = false)]
+    public void TakeDamageServerRpc(int rawDamage, ulong attackerClientId)
+    {
+        if (rawDamage < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rawDamage), "Cannot take negative damage.");
+        }
+
+        // Apply the damage to the crate's health
+        health.Value -= rawDamage;
+
+        Debug.Log($"Crate Health: {health.Value}");
+        AudioManager.instance.PlayDamage();
+
+        // Check if crate health has reached 0
+        if (health.Value <= 0)
+        {
+            StartCoroutine(Break());
+        }
+    }
+
+    private IEnumerator Break()
+    {
+        if (isBreak) yield break;
+        isBreak = true;
+
+        // Play death animation
+        anim.SetBool("Broken", true);
+        yield return new WaitForSeconds(0.5f);
+
+        // Properly despawn the networked object
+        if (IsServer)
+        {
+            // Despawn the crate to sync destruction across all clients
+            GetComponent<NetworkObject>().Despawn();
+        }
+    }
+}

--- a/Siomeow Legends/Assets/Scripts/Objects/CrateStats.cs.meta
+++ b/Siomeow Legends/Assets/Scripts/Objects/CrateStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4479c7b4913eefa4596bddc87616b9e9

--- a/Siomeow Legends/Assets/Scripts/Objects/LootCrate.cs
+++ b/Siomeow Legends/Assets/Scripts/Objects/LootCrate.cs
@@ -1,11 +1,12 @@
 using UnityEngine;
+using Unity.Netcode;
 
-public class Crate : MonoBehaviour
+public class LootCrate : NetworkBehaviour
 {
     public GameObject healthPotionPrefab;
     public GameObject defensePotionPrefab;
 
-    void OnDestroy()
+    new void OnDestroy()
     {
         AudioManager.instance.PlayCrate();
         DropPotion();

--- a/Siomeow Legends/Assets/Scripts/Objects/LootCrate.cs
+++ b/Siomeow Legends/Assets/Scripts/Objects/LootCrate.cs
@@ -6,14 +6,10 @@ public class LootCrate : NetworkBehaviour
     public GameObject healthPotionPrefab;
     public GameObject defensePotionPrefab;
 
-    new void OnDestroy()
+    public void DropPotion()
     {
-        AudioManager.instance.PlayCrate();
-        DropPotion();
-    }
-
-    void DropPotion()
-    {
+        
+        Debug.Log($"Crate here");
         if (Random.Range(0f, 1f) <= 0.5f)
         {
             bool dropHealthPotion = Random.Range(0f, 1f) <= 0.69f;
@@ -21,11 +17,11 @@ public class LootCrate : NetworkBehaviour
 
             if (dropHealthPotion && !dropDefensePotion)
             {
-                Heal();
+                SpawnPotion(healthPotionPrefab);
             }
             else if (dropDefensePotion && !dropHealthPotion)
             {
-                Shield();
+                SpawnPotion(defensePotionPrefab);
             } 
             else
             {
@@ -38,15 +34,18 @@ public class LootCrate : NetworkBehaviour
         }
     }
 
-    void Heal()
+    void SpawnPotion(GameObject potionPrefab)
     {
-        Instantiate(healthPotionPrefab, transform.position, Quaternion.identity);
-        Debug.Log("Health potion dropped.");
-    }    
-    
-    void Shield()
-    {
-        Instantiate(defensePotionPrefab, transform.position, Quaternion.identity);
-        Debug.Log("Defense potion dropped.");
+        GameObject potion = Instantiate(potionPrefab, transform.position, Quaternion.identity);
+        var netObj = potion.GetComponent<NetworkObject>();
+        if (netObj != null)
+        {
+            netObj.Spawn();
+            Debug.Log($"Spawned potion: {potionPrefab.name}");
+        }
+        else
+        {
+            Debug.LogWarning("Potion prefab is missing NetworkObject!");
+        }
     }
 }

--- a/Siomeow Legends/Assets/Scripts/Player/AttackArea.cs
+++ b/Siomeow Legends/Assets/Scripts/Player/AttackArea.cs
@@ -5,6 +5,7 @@ public class AttackArea : MonoBehaviour
 {
     private int minDamage = 80;
     private int maxDamage = 120;
+
     private void OnTriggerEnter2D(Collider2D collider)
     {
         if (collider.GetComponent<PlayerStats>() != null)
@@ -21,5 +22,15 @@ public class AttackArea : MonoBehaviour
 
             Debug.Log($"Normal Damage: {damage} dealt by {attacker.name}.");
         }
+
+        if (collider.GetComponent<CrateStats>() != null)
+        {
+            CrateStats crateTarget = collider.GetComponent<CrateStats>();
+            ulong attackerClientId = GetComponentInParent<NetworkObject>().OwnerClientId;
+            crateTarget.TakeDamageServerRpc(1, attackerClientId);
+            Debug.Log("Crate hit and damaged!");
+        }
     }
+
+    
 }

--- a/Siomeow Legends/Assets/Scripts/Player/PlayerStats.cs
+++ b/Siomeow Legends/Assets/Scripts/Player/PlayerStats.cs
@@ -92,6 +92,9 @@ public class PlayerStats : NetworkBehaviour
         {
             OnStatsChanged?.Invoke();
         }
+    
+        UpdateHealthUIClientRpc(health.Value, MAX_HEALTH);
+        Debug.Log($"Health is now {health.Value}!");
     }
 
     public void IncreaseDefense(int defenseAmount)
@@ -102,6 +105,9 @@ public class PlayerStats : NetworkBehaviour
         {
             OnStatsChanged?.Invoke();
         }
+        
+        UpdateDamageUIClientRpc(defense.Value, MAX_DEFENSE);
+        Debug.Log($"Defense is now {defense.Value}!");
     }
 
     private IEnumerator Die()
@@ -166,9 +172,22 @@ public class PlayerStats : NetworkBehaviour
                 PlayerUIManager.Instance.SetKillCount(newKillCount);
             }
     }
+
     private IEnumerator ResetDamageAnimation()
     {
         yield return new WaitForSeconds(0.5f);
         anim.SetBool("Damage", false);
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void HealServerRpc(int healValue)
+    {
+        Heal(healValue);
+    }
+    
+    [ServerRpc(RequireOwnership = false)]
+    public void IncreaseDefenseServerRpc(int defenseAmount)
+    {
+        IncreaseDefense(defenseAmount);
     }
 }

--- a/Siomeow Legends/Assets/Scripts/Player/PowerUpsHandler.cs
+++ b/Siomeow Legends/Assets/Scripts/Player/PowerUpsHandler.cs
@@ -40,12 +40,12 @@ public class PowerUpsHandler : MonoBehaviour
 
             case PickupItem.PowerUp.Heal:
                 AudioManager.instance.PlayHeal();
-                ApplyHeal();
+                playerStats.HealServerRpc(100); 
                 break;
 
             case PickupItem.PowerUp.Shield:
                 AudioManager.instance.PlayHeal();
-                ApplyShield();
+                playerStats.IncreaseDefenseServerRpc(50); 
                 break;
 
             default:
@@ -120,21 +120,5 @@ public class PowerUpsHandler : MonoBehaviour
         yield return new WaitUntil(() => !player.isDashing);
         player.dashingCooldown = 10f;
         Debug.Log($"Cooldown reset to: {player.dashingCooldown}!");
-    }
-
-    private void ApplyHeal()
-    {
-        int healAmount = 100;
-
-        playerStats.Heal(healAmount);
-        Debug.Log($"Health is now {playerStats.health}!");
-    }
-
-    private void ApplyShield()
-    {
-        int defenseAmount = 50;
-
-        playerStats.IncreaseDefense(defenseAmount);
-        Debug.Log($"Defense is now {playerStats.defense}!");
     }
 }

--- a/Siomeow Legends/Assets/Scripts/Player/RangedAttackBullet.cs
+++ b/Siomeow Legends/Assets/Scripts/Player/RangedAttackBullet.cs
@@ -33,5 +33,13 @@ public class RangedAttackBullet : MonoBehaviour
                 Debug.Log($"Normal Damage: {damage}.");
             }
         }
+
+        if (collider.GetComponent<CrateStats>() != null)
+        {
+            CrateStats crateTarget = collider.GetComponent<CrateStats>();
+            ulong attackerClientId = GetComponentInParent<NetworkObject>().OwnerClientId;
+            crateTarget.TakeDamageServerRpc(1, attackerClientId);
+            Debug.Log("Crate hit and damaged!");
+        }
     }
 }

--- a/Siomeow Legends/Assets/Scripts/Player/RangedSpecialAttackBullet.cs
+++ b/Siomeow Legends/Assets/Scripts/Player/RangedSpecialAttackBullet.cs
@@ -29,5 +29,13 @@ public class RangedSpecialAttackBullet : MonoBehaviour
                 Debug.Log($"Special Damage: {damage} dealt by {attacker.name}.");
             }
         }
+
+        if (collider.GetComponent<CrateStats>() != null)
+        {
+            CrateStats crateTarget = collider.GetComponent<CrateStats>();
+            ulong attackerClientId = GetComponentInParent<NetworkObject>().OwnerClientId;
+            crateTarget.TakeDamageServerRpc(1, attackerClientId);
+            Debug.Log("Crate hit and damaged!");
+        }
     }
 }

--- a/Siomeow Legends/Assets/Scripts/Player/SpecialAttack.cs
+++ b/Siomeow Legends/Assets/Scripts/Player/SpecialAttack.cs
@@ -22,5 +22,13 @@ public class SpecialAttackArea : MonoBehaviour
 
             Debug.Log($"Special Damage: {damage} dealt by {attacker.name}.");
         }
+        
+        if (collider.GetComponent<CrateStats>() != null)
+        {
+            CrateStats crateTarget = collider.GetComponent<CrateStats>();
+            ulong attackerClientId = GetComponentInParent<NetworkObject>().OwnerClientId;
+            crateTarget.TakeDamageServerRpc(1, attackerClientId);
+            Debug.Log("Crate hit and damaged!");
+        }
     }
 }


### PR DESCRIPTION
# UPDATES

- Fixed issue where crates were not breaking properly upon receiving damage
- Resolved potion drop logic to ensure potions are correctly spawned from crates across network
- Fixed player stat updates upon potion pickup
- Ensured UI reflects updated player stats immediately after potion pickup

